### PR TITLE
stripe: fix logic error when checking value of 'school' at report branch

### DIFF
--- a/js/clips/stripe.js
+++ b/js/clips/stripe.js
@@ -219,7 +219,7 @@ monogatari.script ({
                     'Do': 'jump stripe2-report',
                     'Condition': function(){
 						const {school} = monogatari.storage('player');
-						return 6 > school > 4;
+						return school === 5;
 					}
                 }, 
                 'report2': {
@@ -252,7 +252,7 @@ monogatari.script ({
                     'Do': 'jump stripe2-report',
                     'Condition': function(){
 						const {school} = monogatari.storage('player');
-						return 6 > school > 4;
+						return school === 5;
 					}
                 }, 
                 'report2': {
@@ -285,7 +285,7 @@ monogatari.script ({
                     'Do': 'jump stripe2-report',
                     'Condition': function(){
 						const {school} = monogatari.storage('player');
-						return 6 > school > 4;
+						return school === 5;
 					}
                 }, 
                 'report2': {
@@ -318,7 +318,7 @@ monogatari.script ({
                     'Do': 'jump stripe2-report',
                     'Condition': function(){
 						const {school} = monogatari.storage('player');
-						return 6 > school > 4;
+						return school === 5;
 					}
                 }, 
                 'report2': {
@@ -357,7 +357,7 @@ monogatari.script ({
                     'Do': 'jump stripe2-report',
                     'Condition': function(){
 						const {school} = monogatari.storage('player');
-						return 6 > school > 4;
+						return school === 5;
 					}
                 }, 
                 'report2': {
@@ -489,7 +489,7 @@ monogatari.script ({
                     'Do': 'jump stripe3-report',
                     'Condition': function(){
 						const {school} = monogatari.storage('player');
-						return 6 > school > 4;
+						return school === 5;
 					}
                 }, 
                 'report2': {


### PR DESCRIPTION
The condition `6 > school > 4` is equal to `(6 > school) > 4`. `6 > school` is a boolean value which always less than 4, so the condition is always `false`. Use `school > 4 && school < 6`, or more clearly, `school === 5` instead.